### PR TITLE
Use buffered IO to avoid allocations of request/response buffers in the average case

### DIFF
--- a/hopper-distributed/hopper-distributed.cabal
+++ b/hopper-distributed/hopper-distributed.cabal
@@ -56,7 +56,8 @@ library
     , hopper
     , hopper-thrift
     , network
-    , pinch
+    , pinch              >=0.5.0.0
+    , recv
     , serialise
     , streaming-commons
     , time-manager

--- a/hopper-distributed/src/Hopper/Distributed/ThriftClient.hs
+++ b/hopper-distributed/src/Hopper/Distributed/ThriftClient.hs
@@ -6,6 +6,7 @@ module Hopper.Distributed.ThriftClient
 where
 
 import Data.Streaming.Network (getSocketTCP)
+import Hopper.Distributed.ThriftServer (newSocketConnection)
 import Pinch.Client (Client, call, client, createChannel)
 import Pinch.Protocol.Compact (compactProtocol)
 import Pinch.Transport (unframedTransport)
@@ -16,5 +17,6 @@ newClient ::
   IO Client
 newClient host port = do
   (socket, _sockAddr) <- getSocketTCP host port
-  channel <- createChannel socket unframedTransport compactProtocol
+  socketConnection <- newSocketConnection socket
+  channel <- createChannel socketConnection unframedTransport compactProtocol
   pure (client channel)


### PR DESCRIPTION
This PR makes it so that we don't allocate new buffers for read and write IO in the average case. This avoids global locks in the runtime when allocating a large number of bytes.