### PR TITLE
Multiple task status

### DIFF
--- a/hopper-distributed/hopper-distributed.cabal
+++ b/hopper-distributed/hopper-distributed.cabal
@@ -61,6 +61,7 @@ library
     , serialise
     , streaming-commons
     , time-manager
+    , vector
 
   hs-source-dirs:   src
   default-language: Haskell2010

--- a/hopper-thrift/gen-src/Hopper/Thrift/Hopper/Types.hs
+++ b/hopper-thrift/gen-src/Hopper/Thrift/Hopper/Types.hs
@@ -86,15 +86,29 @@ instance Control.DeepSeq.NFData TaskResult
 
 instance Data.Hashable.Hashable TaskResult
 
-data HeartbeatRequest = HeartbeatRequest {heartbeatRequest_task_id :: (Prelude.Maybe TaskId), heartbeatRequest_task_result :: (Prelude.Maybe TaskResult)}
+data TaskStatus = TaskStatus {taskStatus_task_id :: (Prelude.Maybe TaskId), taskStatus_task_result :: (Prelude.Maybe TaskResult)}
+  deriving (Prelude.Eq, GHC.Generics.Generic, Prelude.Show)
+
+instance Pinch.Pinchable TaskStatus where
+  type Tag TaskStatus = Pinch.TStruct
+
+  pinch (TaskStatus taskStatus_task_id taskStatus_task_result) = Pinch.struct ([(1 Pinch.?= taskStatus_task_id), (2 Pinch.?= taskStatus_task_result)])
+
+  unpinch value = ((Prelude.pure (TaskStatus) Prelude.<*> (value Pinch..:? 1)) Prelude.<*> (value Pinch..:? 2))
+
+instance Control.DeepSeq.NFData TaskStatus
+
+instance Data.Hashable.Hashable TaskStatus
+
+data HeartbeatRequest = HeartbeatRequest {heartbeatRequest_task_status :: (Prelude.Maybe (Data.Vector.Vector TaskStatus))}
   deriving (Prelude.Eq, GHC.Generics.Generic, Prelude.Show)
 
 instance Pinch.Pinchable HeartbeatRequest where
   type Tag HeartbeatRequest = Pinch.TStruct
 
-  pinch (HeartbeatRequest heartbeatRequest_task_id heartbeatRequest_task_result) = Pinch.struct ([(1 Pinch.?= heartbeatRequest_task_id), (2 Pinch.?= heartbeatRequest_task_result)])
+  pinch (HeartbeatRequest heartbeatRequest_task_status) = Pinch.struct ([(1 Pinch.?= heartbeatRequest_task_status)])
 
-  unpinch value = ((Prelude.pure (HeartbeatRequest) Prelude.<*> (value Pinch..:? 1)) Prelude.<*> (value Pinch..:? 2))
+  unpinch value = (Prelude.pure (HeartbeatRequest) Prelude.<*> (value Pinch..:? 1))
 
 instance Control.DeepSeq.NFData HeartbeatRequest
 

--- a/hopper-thrift/thrift/hopper.thrift
+++ b/hopper-thrift/thrift/hopper.thrift
@@ -18,9 +18,13 @@ union TaskResult {
     3: Timeout timeout;
 }
 
-struct HeartbeatRequest {
+struct TaskStatus {
     1: optional TaskId task_id;
-    2: optional TaskResult task_result;
+    2: optional TaskResult task_result;    
+}
+
+struct HeartbeatRequest {
+    1: optional list<TaskStatus> task_status;
 }
 
 service Scheduler {


### PR DESCRIPTION
This PR changes the protocol in such a way that executors can now report multiple task status at once. This is in preparation for the a refactoring of the executor logic in which it will be possible to request more than one task at a time from a scheduler.